### PR TITLE
Update ISL 1.0 schema to allow schema header iff schema footer is present

### DIFF
--- a/isl/ion_schema_1_0/schema.isl
+++ b/isl/ion_schema_1_0/schema.isl
@@ -32,13 +32,30 @@ type::{
 type::{
   name: schema,
   type: document,
+  any_of:[
+    schema_with_header_and_footer,
+    schema_without_header_and_footer,
+  ],
+}
+
+type::{
+  name: schema_without_header_and_footer,
+  ordered_elements: [
+    { type: $non_isl, occurs: range::[0, max] },
+    { valid_values: [$ion_schema_1_0], occurs: optional },
+    { type: type_or_$non_isl, occurs: range::[0, max] },
+  ],
+}
+
+type::{
+  name: schema_with_header_and_footer,
   ordered_elements: [
     { type: $non_isl, occurs: range::[0, max] },
     { valid_values: [$ion_schema_1_0], occurs: optional },
     { type: $non_isl, occurs: range::[0, max] },
-    { type: schema_header, occurs: optional },
+    { type: schema_header },
     { type: type_or_$non_isl, occurs: range::[0, max] },
-    { type: schema_footer, occurs: optional },
+    { type: schema_footer },
     { type: $non_isl, occurs: range::[0, max] },
   ],
 }


### PR DESCRIPTION
### Issue #, if available:

None

### Description of changes:

ISL for ISL 1.0 _should_ say that a schema document is invalid when it has
* a header but no footer
* a footer but no header

This change requires them to be cooccurring, as is described by the specification.

----
_**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**_
