### PR TITLE
Updates ISL for ISL 2.0 for amazon-ion/ion-schema#118

### DIFF
--- a/isl/ion_schema_2_0/schema.isl
+++ b/isl/ion_schema_2_0/schema.isl
@@ -18,16 +18,18 @@ type::{
         { type: top_level_open_content, occurs: range::[0, max] },
         isl_2_0_version_marker,
         { type: top_level_open_content, occurs: range::[0, max] },
-        schema_header,
+        { type: schema_header, occurs: optional },
         { one_of: [top_level_open_content, named_type_definition], occurs: range::[0, max] },
         schema_footer,
-        { type: top_level_open_content, occurs: range::[0, max] },
+        { type: $any, occurs: range::[0, max] },
       ]
     },
     {
       ordered_elements: [
         { type: top_level_open_content, occurs: range::[0, max] },
         isl_2_0_version_marker,
+        { type: top_level_open_content, occurs: range::[0, max] },
+        { type: schema_header, occurs: optional },
         { one_of: [top_level_open_content, named_type_definition], occurs: range::[0, max] },
       ]
     }


### PR DESCRIPTION
### Issue #, if available:

Follow up to amazon-ion/ion-schema#118

### Description of changes:

Since the footer is now the end of the schema, if a footer is present, then `$any` can be after the footer. Also, header can be optionally present whether or not the footer is present.

----
_**By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**_
